### PR TITLE
Moving `mixout` function to `functional` module.

### DIFF
--- a/mixout/functional/__init__.py
+++ b/mixout/functional/__init__.py
@@ -1,0 +1,13 @@
+import torch
+from ..mixout import Mixout
+from typing import Optional
+from collections import OrderedDict
+
+
+def mixout(input:torch.Tensor, 
+           target:Optional["OrderedDict[str, torch.Tensor]"]=None, 
+           p:float=0.0, 
+           training:bool=False, 
+           inplace:bool=False) -> torch.Tensor:
+
+    return Mixout.apply(input, target, p, training, inplace)

--- a/mixout/mixlinear.py
+++ b/mixout/mixlinear.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 from torch.nn import Parameter
 from typing import Optional
 from collections import OrderedDict
-from functional import mixout
+from .functional import mixout
 
 
 

--- a/mixout/mixlinear.py
+++ b/mixout/mixlinear.py
@@ -7,13 +7,12 @@
 ##++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 import math
 import torch
-from torch import nn
 import torch.nn.init as init
 import torch.nn.functional as F
 from torch.nn import Parameter
-from mixout import mixout
 from typing import Optional
 from collections import OrderedDict
+from functional import mixout
 
 
 

--- a/mixout/mixout.py
+++ b/mixout/mixout.py
@@ -77,11 +77,3 @@ class Mixout(InplaceFunction):
             return grad_output * ctx.noise, None, None, None, None
         else:
             return grad_output, None, None, None, None
-
-def mixout(input:torch.Tensor, 
-           target:Optional["OrderedDict[str, torch.Tensor]"]=None, 
-           p:float=0.0, 
-           training:bool=False, 
-           inplace:bool=False) -> torch.Tensor:
-
-    return Mixout.apply(input, target, p, training, inplace)

--- a/test.py
+++ b/test.py
@@ -1,8 +1,0 @@
-import torch
-from torch import nn
-from mixout import MixLinear
-
-class Model(nn.Module):
-    def __init__(self):
-        super(Model, self).__init__()
-        self.linear = MixLinear(in_features=1, out_features=1, p=0.4)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,8 @@
+import torch
+from torch import nn
+from mixout import MixLinear
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+        self.linear = MixLinear(in_features=1, out_features=1, p=0.4)


### PR DESCRIPTION
Moved `mixout` function to the `functional` module, because the previous version had some bugs with this. Also, it improves the quality of code. 